### PR TITLE
docs: add Agent Skills section to Laravel and Next.js documentation

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="93b657df-60f6-4757-9e6e-760a0be2bb5d" name="Changes" comment="docs: add initial documentation structure and setup guide for the project">
+    <list default="true" id="93b657df-60f6-4757-9e6e-760a0be2bb5d" name="Changes" comment="docs: update card links and descriptions in index.mdx for consistency">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/content/docs/vexts/codebase/index.mdx" beforeDir="false" afterPath="$PROJECT_DIR$/content/docs/vexts/codebase/index.mdx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/content/docs/(vngne)/styleguide/coding-standards/laravel.mdx" beforeDir="false" afterPath="$PROJECT_DIR$/content/docs/(vngne)/styleguide/coding-standards/laravel.mdx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -40,25 +40,25 @@
     <option name="openDirectoriesWithSingleClick" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "next16",
-    "js.debugger.nextJs.config.created.client": "true",
-    "js.debugger.nextJs.config.created.server": "true",
-    "last_opened_file_path": "/Users/me/git/docs/components",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "pnpm",
-    "settings.editor.selected.configurable": "MTOtherSettingsConfigurable",
-    "ts.external.directory.path": "/Users/me/git/docs/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;next16&quot;,
+    &quot;js.debugger.nextJs.config.created.client&quot;: &quot;true&quot;,
+    &quot;js.debugger.nextJs.config.created.server&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/me/git/docs/components&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;pnpm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;MTOtherSettingsConfigurable&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/me/git/docs/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/components" />
@@ -115,7 +115,8 @@
       <workItem from="1775612490714" duration="74000" />
       <workItem from="1775612635937" duration="180000" />
       <workItem from="1775612888151" duration="38000" />
-      <workItem from="1775612973230" duration="5337000" />
+      <workItem from="1775612973230" duration="5514000" />
+      <workItem from="1775810298738" duration="314000" />
     </task>
     <task id="LOCAL-00001" summary="refactor: rename layout and page files for improved structure">
       <option name="closed" value="true" />
@@ -181,7 +182,15 @@
       <option name="project" value="LOCAL" />
       <updated>1775619100135</updated>
     </task>
-    <option name="localTasksCounter" value="9" />
+    <task id="LOCAL-00009" summary="docs: update card links and descriptions in index.mdx for consistency">
+      <option name="closed" value="true" />
+      <created>1775619938816</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1775619938816</updated>
+    </task>
+    <option name="localTasksCounter" value="10" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -200,6 +209,7 @@
     <MESSAGE value="docs: add extensions for Conventional Commits and GitHub Copilot to documentation" />
     <MESSAGE value="docs: update Laravel and Next.js documentation with additional recommended tools and folder structure" />
     <MESSAGE value="docs: add initial documentation structure and setup guide for the project" />
-    <option name="LAST_COMMIT_MESSAGE" value="docs: add initial documentation structure and setup guide for the project" />
+    <MESSAGE value="docs: update card links and descriptions in index.mdx for consistency" />
+    <option name="LAST_COMMIT_MESSAGE" value="docs: update card links and descriptions in index.mdx for consistency" />
   </component>
 </project>

--- a/content/docs/(vngne)/styleguide/coding-standards/laravel.mdx
+++ b/content/docs/(vngne)/styleguide/coding-standards/laravel.mdx
@@ -672,6 +672,11 @@ DB | MySQL, PostgreSQL, SQLite, SQL Server | MongoDB
 
 ---
 
+## Agent Skills
+```bash title="Terminal"
+ php artisan boost:add-skill ekovegeance/agent-skills/skills/laravel
+```
+
 ## Recommend Tools & Configuration
 - [Awesomecode](https://marketplace.visualstudio.com/items?itemName=ekovegeance.awesomecode) theme and code editor setup for VS Code
 - [Laravel Herd](https://herd.laravel.com/) PHP development environment.

--- a/content/docs/(vngne)/styleguide/coding-standards/nextjs.mdx
+++ b/content/docs/(vngne)/styleguide/coding-standards/nextjs.mdx
@@ -266,6 +266,10 @@ export default eslintConfig;
   "printWidth": 80
 }
 ```
+## Agent Skills
+```bash title="Terminal"
+  npx skills add https://github.com/ekovegeance/agent-skills --skill nextjs
+```
 
 ## Recommend Tools & Configuration
 - [Awesomecode](https://marketplace.visualstudio.com/items?itemName=ekovegeance.awesomecode) theme and code editor setup for VS Code


### PR DESCRIPTION
This pull request primarily updates documentation and project configuration to improve consistency and add new usage instructions. The most important changes are grouped below:

**Documentation Updates:**

* Added an "Agent Skills" section to the Laravel coding standards documentation, including instructions for adding the Laravel skill via `php artisan boost:add-skill`.
* Added an "Agent Skills" section to the Next.js coding standards documentation, with instructions for adding the Next.js skill using `npx skills add`.

**Project Configuration and Metadata:**

* Updated the `.idea/workspace.xml` file to reflect the new documentation update task, update commit message history, and adjust task durations and counters for better tracking and consistency. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL7-R9) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL43-R61) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL118-R119) [[4]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL184-R193) [[5]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL203-R213)