### PR TITLE
feat: add new feature release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ignore
+    authors:
+      - github-actions[bot]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,4 @@ jobs:
         with:
           release-type: node
           target-branch: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="93b657df-60f6-4757-9e6e-760a0be2bb5d" name="Changes" comment="docs: update task metadata and last commit message for improved documentation clarity">
-      <change beforePath="$PROJECT_DIR$/.github/workflows/release.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/release.yml" afterDir="false" />
+    <list default="true" id="93b657df-60f6-4757-9e6e-760a0be2bb5d" name="Changes" comment="feat: release">
+      <change afterPath="$PROJECT_DIR$/.github/release.yml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -288,7 +288,15 @@
       <option name="project" value="LOCAL" />
       <updated>1778925433591</updated>
     </task>
-    <option name="localTasksCounter" value="21" />
+    <task id="LOCAL-00021" summary="feat: release">
+      <option name="closed" value="true" />
+      <created>1778926394022</created>
+      <option name="number" value="00021" />
+      <option name="presentableId" value="LOCAL-00021" />
+      <option name="project" value="LOCAL" />
+      <updated>1778926394022</updated>
+    </task>
+    <option name="localTasksCounter" value="22" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -317,6 +325,7 @@
     <MESSAGE value="docs: update metadata and add author component for improved documentation" />
     <MESSAGE value="docs: add new documentation for runtime selection, suspense boundaries, and error handling" />
     <MESSAGE value="docs: update task metadata and last commit message for improved documentation clarity" />
-    <option name="LAST_COMMIT_MESSAGE" value="docs: update task metadata and last commit message for improved documentation clarity" />
+    <MESSAGE value="feat: release" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat: release" />
   </component>
 </project>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features", "hidden": false },
+        { "type": "fix", "section": "Bug Fixes", "hidden": false },
+        { "type": "perf", "section": "Performance", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "style", "section": "Styles", "hidden": false }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces configuration for automated releases using Release Please and makes related updates to workflow and project files. The main focus is on enabling structured changelogs and customizing the release workflow.

**Release automation and configuration:**

* Added a new `release-please-config.json` file to define release types and changelog sections for the project, enabling structured and categorized changelogs.
* Updated the GitHub Actions workflow (`.github/workflows/release.yml`) to use the new config file for Release Please and removed the explicit `GITHUB_TOKEN` environment variable from the release job.
* Added a `.github/release.yml` file to exclude specific labels (e.g., `ignore`) and authors (e.g., `github-actions[bot]`) from the changelog.

**Project metadata updates:**

* Updated `.idea/workspace.xml` to reflect the new release task, including commit messages and task counters, for improved project tracking. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL7-R8) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL291-R299) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL320-R329)